### PR TITLE
Add impersonate route hack using token

### DIFF
--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -6,7 +6,7 @@ import { KubeFastifyInstance } from '../../../types';
 import {
   DEV_IMPERSONATE_PASSWORD,
   DEV_IMPERSONATE_USER,
-  DEV_IMPERSONATE_TOKEN,  // Temporary work around: get impersonate to work through token, becuase of hostname resolve problem and IBM not using oauth proxy
+  DEV_IMPERSONATE_TOKEN,  // Temporary workaround: get impersonate to work through a token, because of hostname resolve the problem and IBM not using OAuth proxy
 } from '../../../utils/constants';
 import { createCustomError } from '../../../utils/requestUtils';
 import { devRoute } from '../../../utils/route-security';
@@ -16,7 +16,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
     '/',
     devRoute(async (request: FastifyRequest<{ Body: { impersonate: boolean } }>) => {
       return new Promise<{ code: number; response: string }>((resolve, reject) => {
-        // Temporary work around: get impersonate to work through token, becuase of hostname resolve problem and IBM not using oauth proxy
+        // Temporary workaround: get impersonate to work through a token, because of hostname resolve the problem and IBM not using OAuth proxy
         if (DEV_IMPERSONATE_TOKEN) {
           setImpersonateAccessToken(DEV_IMPERSONATE_TOKEN);
           resolve({ code: 200, response: DEV_IMPERSONATE_TOKEN });

--- a/backend/src/routes/api/dev-impersonate/index.ts
+++ b/backend/src/routes/api/dev-impersonate/index.ts
@@ -3,7 +3,11 @@ import https from 'https';
 import createError from 'http-errors';
 import { setImpersonateAccessToken } from '../../../devFlags';
 import { KubeFastifyInstance } from '../../../types';
-import { DEV_IMPERSONATE_PASSWORD, DEV_IMPERSONATE_USER } from '../../../utils/constants';
+import {
+  DEV_IMPERSONATE_PASSWORD,
+  DEV_IMPERSONATE_USER,
+  DEV_IMPERSONATE_TOKEN,  // Temporary work around: get impersonate to work through token, becuase of hostname resolve problem and IBM not using oauth proxy
+} from '../../../utils/constants';
 import { createCustomError } from '../../../utils/requestUtils';
 import { devRoute } from '../../../utils/route-security';
 
@@ -12,6 +16,12 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
     '/',
     devRoute(async (request: FastifyRequest<{ Body: { impersonate: boolean } }>) => {
       return new Promise<{ code: number; response: string }>((resolve, reject) => {
+        // Temporary work around: get impersonate to work through token, becuase of hostname resolve problem and IBM not using oauth proxy
+        if (DEV_IMPERSONATE_TOKEN) {
+          setImpersonateAccessToken(DEV_IMPERSONATE_TOKEN);
+          resolve({ code: 200, response: DEV_IMPERSONATE_TOKEN });
+          return;
+        }
         const doImpersonate = request.body.impersonate;
         if (doImpersonate) {
           const apiPath = fastify.kube.config.getCurrentCluster().server;
@@ -71,7 +81,7 @@ export default async (fastify: KubeFastifyInstance): Promise<void> => {
         if (e?.code) {
           throw createCustomError(
             'Error impersonating user',
-            e.response?.message || 'Impersonating user error',
+            e.response || 'Impersonating user error',
             e.code,
           );
         }

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -10,7 +10,7 @@ export const DEV_MODE = process.env.APP_ENV === 'development';
 /** Allows a username to be impersonated in place of the logged in user for testing purposes -- impacts only some API */
 export const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 export const DEV_IMPERSONATE_PASSWORD = DEV_MODE ? process.env.DEV_IMPERSONATE_PASSWORD : undefined;
-export const DEV_IMPERSONATE_TOKEN = DEV_MODE ? process.env.DEV_IMPERSONATE_TOKEN : undefined; // Temporary work around: get impersonate to work through token, becuase of hostname resolve problem and IBM not using oauth proxy
+export const DEV_IMPERSONATE_TOKEN = DEV_MODE ? process.env.DEV_IMPERSONATE_TOKEN : undefined; // Temporary workaround: get impersonate to work through a token, because of hostname resolve the problem and IBM not using OAuth proxy
 export const APP_ENV = process.env.APP_ENV;
 
 export const USER_ACCESS_TOKEN = 'x-forwarded-access-token';

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -10,6 +10,7 @@ export const DEV_MODE = process.env.APP_ENV === 'development';
 /** Allows a username to be impersonated in place of the logged in user for testing purposes -- impacts only some API */
 export const DEV_IMPERSONATE_USER = DEV_MODE ? process.env.DEV_IMPERSONATE_USER : undefined;
 export const DEV_IMPERSONATE_PASSWORD = DEV_MODE ? process.env.DEV_IMPERSONATE_PASSWORD : undefined;
+export const DEV_IMPERSONATE_TOKEN = DEV_MODE ? process.env.DEV_IMPERSONATE_TOKEN : undefined; // Temporary work around: get impersonate to work through token, becuase of hostname resolve problem and IBM not using oauth proxy
 export const APP_ENV = process.env.APP_ENV;
 
 export const USER_ACCESS_TOKEN = 'x-forwarded-access-token';


### PR DESCRIPTION
Temporary workaround: get impersonate to work through a token, because of hostname resolve the problem and IBM not using OAuth proxy