### PR TITLE
Updates for dashboard integration with odh proper

### DIFF
--- a/frontend/src/pages/MCADashboard/MCADTabs.tsx
+++ b/frontend/src/pages/MCADashboard/MCADTabs.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Tabs, Tab, TabTitleText, TabTitleIcon } from '@patternfly/react-core';
-import UsersIcon from '@patternfly/react-icons/dist/esm/icons/users-icon';
+//import UsersIcon from '@patternfly/react-icons/dist/esm/icons/users-icon';
 // import BoxIcon from '@patternfly/react-icons/dist/esm/icons/box-icon';
 import DatabaseIcon from '@patternfly/react-icons/dist/esm/icons/database-icon';
 // import ServerIcon from '@patternfly/react-icons/dist/esm/icons/server-icon';
 // import LaptopIcon from '@patternfly/react-icons/dist/esm/icons/laptop-icon';
+import DeezerIcon from '@patternfly/react-icons/dist/esm/icons/deezer-icon';
 import ProjectDiagramIcon from '@patternfly/react-icons/dist/esm/icons/project-diagram-icon';
 import { useWatchComponents } from '~/utilities/useWatchComponents';
 import ApplicationsPage from '~/pages/ApplicationsPage';
@@ -54,9 +55,9 @@ export const MCADTabs: React.FunctionComponent = () => {
           title={
             <>
               <TabTitleIcon>
-                <UsersIcon />
+                <DeezerIcon />
               </TabTitleIcon>
-              <TabTitleText>Dashboard</TabTitleText>
+              <TabTitleText>Appwrapper Summary</TabTitleText>
             </>
           }
           aria-label="mcad-dashboard-tab"

--- a/frontend/src/pages/MCADashboard/Tables/quota-table.tsx
+++ b/frontend/src/pages/MCADashboard/Tables/quota-table.tsx
@@ -116,7 +116,7 @@ export const QuotaTable: React.FunctionComponent<QuotaViewProps> = ({
     },
     {
       field: 'numberofappwrappers',
-      label: '# of Appwrappers',
+      label: 'Appwrappers',
       sortable: true,
     },
     {

--- a/frontend/src/utilities/NavData.tsx
+++ b/frontend/src/utilities/NavData.tsx
@@ -132,14 +132,14 @@ export const getNavBarData = (
       });
     }
   }
+  // MCAD dashboard
+  navItems.push({ id: 'mcad', label: 'MCAD Dashboard', href: '/mcad' }); 
 
   if (featureFlagEnabled(dashboardConfig.spec.dashboardConfig.disableModelServing)) {
     navItems.push({ id: 'modelServing', label: 'Model Serving', href: '/modelServing' });
   }
 
   navItems.push({ id: 'resources', label: 'Resources', href: '/resources' });
-
-  navItems.push({ id: 'mcad', label: 'MCAD Dashboard', href: '/mcad' }); // path created for MCAD dashboard
   
   const settingsNav = getSettingsNav(isAdmin, dashboardConfig);
   if (settingsNav) {


### PR DESCRIPTION
- Move MCAD dashboard tab on left-nav above model-serving tab
- Changing "Dashboard" tab name to  “Appwrapper Summary”
- Changing "# of Appwrappers" to "Appwrappers" under quota summary table